### PR TITLE
Patch for xior response interceptors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.2-alpha.0",
+    "version": "0.1.2-alpha.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.1.2-alpha.0",
+            "version": "0.1.2-alpha.1",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.2-alpha.2",
+    "version": "0.2.1-alpha.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.1.2-alpha.2",
+            "version": "0.2.1-alpha.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.2-alpha.1",
+    "version": "0.1.2-alpha.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.1.2-alpha.1",
+            "version": "0.1.2-alpha.2",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.2.1-alpha.0",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.2.1-alpha.0",
+            "version": "0.3.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "xior": "^0.3.12"
             },
             "peerDependencies": {
-                "xior": "^0.3.12"
+                "xior": "^0.4.0"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.1",
+    "version": "0.1.2-alpha.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "xior-auth-refresh",
-            "version": "0.1.1",
+            "version": "0.1.2-alpha.0",
             "license": "MIT",
             "devDependencies": {
                 "@types/jest": "^28.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.2-alpha.2",
+    "version": "0.2.0",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",
@@ -49,7 +49,7 @@
         "prepare": "husky install"
     },
     "peerDependencies": {
-        "xior": "^0.3.12"
+        "xior": "^0.4.0"
     },
     "devDependencies": {
         "bunchee": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.2.1-alpha.0",
+    "version": "0.3.0",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.2.0",
+    "version": "0.2.1-alpha.0",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.2-alpha.1",
+    "version": "0.1.2-alpha.2",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.1",
+    "version": "0.1.2-alpha.0",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xior-auth-refresh",
-    "version": "0.1.2-alpha.0",
+    "version": "0.1.2-alpha.1",
     "description": "Xior plugin which makes it very easy to automatically refresh the authorization tokens of your clients",
     "keywords": [
         "xior",

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,9 +55,7 @@ export default function createAuthRefreshInterceptor(
             options = mergeOptions(defaultOptions, options);
 
             if (!shouldInterceptError(error, options, instance, cache)) {
-                // https://github.com/suhaotian/xior/issues/15 - in current version this will stop the reject chain
-                //return Promise.reject(error);
-                return;
+                return Promise.reject(error);
             }
 
             if (options.pauseInstanceWhileRefreshing) {
@@ -70,17 +68,10 @@ export default function createAuthRefreshInterceptor(
             // Create interceptor that will bind all the others requests until refreshAuthCall is resolved
             createRequestQueueInterceptor(instance, cache, options);
 
-            return (
-                refreshing
-                    // https://github.com/suhaotian/xior/issues/15 - in current version this will stop the reject chain
-                    //.catch((error) => Promise.reject(error))
-                    .then(() => resendFailedRequest(error, getRetryInstance(instance, options)))
-                    // However, if we were successful, we now want to stop the reject chain
-                    // This will break any response intercepts which run for successful responses after, but that is
-                    // broken currently anyway (it isn't the same as axios - https://github.com/axios/axios?tab=readme-ov-file#multiple-interceptors)
-                    //.then(() => Promise.reject(error))
-                    .finally(() => unsetCache(instance, cache))
-            );
+            return refreshing
+                .catch((error) => Promise.reject(error))
+                .then(() => resendFailedRequest(error, getRetryInstance(instance, options)))
+                .finally(() => unsetCache(instance, cache));
         }
     );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export default function createAuthRefreshInterceptor(
                     // However, if we were successful, we now want to stop the reject chain
                     // This will break any response intercepts which run for successful responses after, but that is
                     // broken currently anyway (it isn't the same as axios - https://github.com/axios/axios?tab=readme-ov-file#multiple-interceptors)
-                    .then(() => Promise.reject(error))
+                    //.then(() => Promise.reject(error))
                     .finally(() => unsetCache(instance, cache))
             );
         }


### PR DESCRIPTION
See related issue: https://github.com/suhaotian/xior/issues/15

At the moment, rejecting the promise stops other reject handlers firing in later response interceptors.

This is a temporary patch to deal with this case:

We don't reject if we aren't running
We reject when we have successfully run the refresh to stop other reject handlers running
Known issues:

Later response interceptors fulfill handlers won't run - but in the current version of xior they aren't running anyway